### PR TITLE
Generalize clipboard feature for platform independence

### DIFF
--- a/bin/http-tunnel.js
+++ b/bin/http-tunnel.js
@@ -43,14 +43,25 @@ process.on('uncaughtException', function(error) {
   logger.error('Uncaught error', { info: error, stack: error.stack });
 });
 
-function copyToClipboard(str, cb) {
-  var spawn = require('child_process').spawn
-    , pbcopy = spawn('pbcopy');
-  pbcopy.on('exit', function (code) {
-    if (cb) cb(code == 0);
-  });
-  pbcopy.stdin.write(str + '\n');
-  pbcopy.stdin.end();
+var subprocessClipboard = function(process_name) {
+  return function(str, cb) {
+    var spawn = require('child_process').spawn
+      , clipboard = spawn(process_name);
+    clipboard.on('exit', function (code) {
+      if (cb) cb(code == 0);
+    });
+    clipboard.stdin.write(str + '\n');
+    clipboard.stdin.end();
+  }
+}
+
+var copyToClipboard;
+if (process.platform === 'win32') {
+  copyToClipboard = subprocessClipboard('clip');
+} else if (process.platform === 'darwin') {
+  copyToClipboard = subprocessClipboard('pbcopy');
+} else {
+  copyToClipboard = function(/*str, cb*/){};
 }
 
 function bindWithServer(host, callback) {


### PR DESCRIPTION
The copyToClipboard function would fail unless the platform was Mac OS X
(Or, strictly speaking, if there was no 'pbcopy' binary available). This
patch fixes it so the code runs on Windows. For any other platform it will
now be a noop (which I think is better than having it crash which was the
case before..)
